### PR TITLE
Added missing long for number of frames in group

### DIFF
--- a/qkspec_5.htm
+++ b/qkspec_5.htm
@@ -449,6 +449,7 @@ struct
 <PRE> 
 struct
 { long type;                   // Value != 0
+  long nb;                     // number of simple frames in group
   trivertx_t min;              // min position in all simple frames
   trivertx_t max;              // max position in all simple frames
   float time[nb]               // time for each of the single frames


### PR DESCRIPTION
This field missing from the documentation will cause byte-alignment and data-validity issues for models like fires and torches (as I just discovered).