### PR TITLE
Update qkspec_4.htm

### DIFF
--- a/qkspec_4.htm
+++ b/qkspec_4.htm
@@ -689,7 +689,7 @@ number of faces was not possible.</P>
 <a href="qkspec_4.htm#BL7" target="content">faces</A> can be reconstituted.</P>
 
 <P><PRE>
-short lstedge[numlstedge];
+long lstedge[numlstedge];
 </PRE></P>
 
 <P>All the edges in a <a href="qkspec_4.htm#BL7" target="content">face</A> are stored


### PR DESCRIPTION
In list of edges, the indexes are a 32-bit signed integer, not a short.